### PR TITLE
Add fixtures for game objects

### DIFF
--- a/frontend/src/fixtures/gamesFixtures.js
+++ b/frontend/src/fixtures/gamesFixtures.js
@@ -1,0 +1,46 @@
+const gamesFixtures = {
+    oneGame:
+    [
+      {
+        "id": 1,
+        "name": "Super Mario Bros.",
+        "developer": "Nintendo",
+        "publisher": "Nintendo",
+        "year": "1985",
+        "rating": "E"
+      }
+    ],
+
+    threeGames:
+    [
+      {
+        "id": 2,
+        "name": "Doom",
+        "developer": "id Software",
+        "publisher": "id Software",
+        "year": "1993",
+        "rating": "M"
+      },
+        
+      {
+        "id": 3,
+        "name": "Sonic Unleashed",
+        "developer": "Sonic Team",
+        "publisher": "Sega",
+        "year": "2008",
+        "rating": "E10+"
+      },
+
+      {
+        "id": 4,
+        "name": "Ratchet & Clank",
+        "developer": "Insomniac Games",
+        "publisher": "Sony Computer Entertainment",
+        "year": "2002",
+        "rating": "T"
+      },
+ 
+    ]
+};
+
+export { gamesFixtures };


### PR DESCRIPTION
In this PR, we add fixtures for games objects to be used in testing and storybook entries.