### PR TITLE
Fix games form

### DIFF
--- a/frontend/src/main/components/Games/GamesForm.js
+++ b/frontend/src/main/components/Games/GamesForm.js
@@ -67,23 +67,6 @@ function GamesForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                 </Form.Control.Feedback>
             </Form.Group>
 
-            <Form.Group className="mb-3" >
-                <Form.Label htmlFor="year">Year</Form.Label>
-                <Form.Control
-                    data-testid={testIdPrefix + "-year"}
-                    id="year"
-                    type="text"
-                    isInvalid={Boolean(errors.year)}
-                    {...register("year", {
-                        required: "Year is required."
-                    })}
-                />
-                <Form.Control.Feedback type="invalid">
-                    {errors.year?.message}
-                </Form.Control.Feedback>
-            </Form.Group>
-
-
             <Button
                 type="submit"
                 data-testid={testIdPrefix + "-submit"}

--- a/frontend/src/main/pages/Games/GamesCreatePage.js
+++ b/frontend/src/main/pages/Games/GamesCreatePage.js
@@ -3,7 +3,7 @@ import GamesForm from "main/components/Games/GamesForm";
 import { useNavigate } from 'react-router-dom'
 import { gamesUtils } from 'main/utils/gamesUtils';
 
-export default function RestaurantCreatePage() {
+export default function GamesCreatePage() {
 
   let navigate = useNavigate(); 
 

--- a/frontend/src/tests/components/Games/GamesForm.test.js
+++ b/frontend/src/tests/components/Games/GamesForm.test.js
@@ -16,7 +16,7 @@ jest.mock('react-router-dom', () => ({
 describe("GamesForm tests", () => {
     const queryClient = new QueryClient();
 
-    const expectedHeaders = ["Name","Developer","Year"];
+    const expectedHeaders = ["Name","Developer"];
     const testId = "GamesForm";
 
     test("renders correctly with no initialContents", async () => {


### PR DESCRIPTION
This fixes the errors introduced in #40. The issue is that the tests did not account for the additional field `Year` marked as required. The alternative fix is to pass in year in `GamesCreatePage.test.js` and `GamesEditPage.test.js`, but for consistency with the other categories I removed the extra field. Please validate any UI changes.